### PR TITLE
fix macOS compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,6 @@ target_link_libraries(
     fftw3
 )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
-
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wpedantic")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,13 @@ include_directories(
     third_party/portaudio/src/common/
 )
 
+if(APPLE)
+    SET(CMAKE_CXX_STANDARD 11)
+    include_directories(/usr/local/include)
+endif()
+
 file(GLOB nicescope_files src/*.cpp)
 add_executable(NiceScope ${nicescope_files})
-
 
 target_link_libraries(
     NiceScope

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(
 if(APPLE)
     SET(CMAKE_CXX_STANDARD 11)
     include_directories(/usr/local/include)
+    link_directories(/usr/local/lib)
 endif()
 
 file(GLOB nicescope_files src/*.cpp)
@@ -25,6 +26,8 @@ target_link_libraries(
     portaudio_static
     fftw3
 )
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wpedantic")

--- a/src/FFT.cpp
+++ b/src/FFT.cpp
@@ -106,7 +106,7 @@ void FFT::process(Ingress& ingress)
         if (index < 0) {
             index += ingress.getBufferSize();
         }
-        m_samples[i] = ingress.getOutputBuffer().get()[index] * m_window[i];
+        m_samples[i] = ingress.getOutputBuffer()[index] * m_window[i];
     }
     doFFT();
 }

--- a/src/FFT.hpp
+++ b/src/FFT.hpp
@@ -15,7 +15,7 @@ public:
     void process(InputBuffer input_buffer, OutputBuffer output_buffer, int frame_count) override;
 
     void bufferSamples();
-    std::shared_ptr<float[]> getOutputBuffer() { return m_outputBuffer; };
+    const float* getOutputBuffer() { return m_outputBuffer.get(); };
     int getNumChannels() { return m_numChannels; };
     int getBufferSize() { return m_outputBufferSize; };
     int getWritePos() { return m_writePos; };
@@ -33,7 +33,7 @@ private:
 
     std::unique_ptr<float[]> m_scratchBuffer;
 
-    std::shared_ptr<float[]> m_outputBuffer;
+    std::unique_ptr<float[]> m_outputBuffer;
 };
 
 class FFT {

--- a/src/portaudio_backend.cpp
+++ b/src/portaudio_backend.cpp
@@ -15,8 +15,6 @@ void PortAudioBackend::run()
     int device = find_device();
     auto device_info = Pa_GetDeviceInfo(device);
 
-    std::cout << "max input channels: " << device_info->maxInputChannels << std::endl;
-
     input_parameters.device = device;
     input_parameters.channelCount = m_numChannels;
     input_parameters.sampleFormat = sample_format;
@@ -85,7 +83,6 @@ int PortAudioBackend::find_device()
         int device_index = Pa_HostApiDeviceIndexToDeviceIndex(host_api_index, i);
         const PaDeviceInfo* info = Pa_GetDeviceInfo(device_index);
         std::string name = info->name;
-        std::cout << name << std::endl;
         if (name == m_device) {
             return device_index;
         }


### PR DESCRIPTION
Regarding #14.

Originally the request was to use a CMake module to find FFTW but it turns out CMake couldn't find any external dependency installed by homebrew. So I added a conditional section to the CMakeLists.txt to add the homebrew path if on macOS. I also had to set the C++ standard to C++11.

Unfortunately this build is still broken, so merging it won't fix the macOS build quite yet. The next compilation error is:

```
/Users/luken/src/ext/NiceScope/src/FFT.cpp:27:23: error: type 'std::shared_ptr<float []>' does not provide a subscript operator
        m_outputBuffer[i] = 0;
        ~~~~~~~~~~~~~~^~
/Users/luken/src/ext/NiceScope/src/FFT.cpp:47:29: error: subscript of pointer to incomplete type 'std::__1::shared_ptr<float []>::element_type'
      (aka 'float []')
        m_outputBuffer.get()[m_writePos] = m_scratchBuffer.get()[i];
        ~~~~~~~~~~~~~~~~~~~~^
/Users/luken/src/ext/NiceScope/src/FFT.cpp:109:55: error: subscript of pointer to incomplete type 'std::__1::shared_ptr<float []>::element_type'
      (aka 'float []')
        m_samples[i] = ingress.getOutputBuffer().get()[index] * m_window[i];
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
```

So using `shared_ptr<float[]>` to point to array types is actually not supported by the standard. See, for example this [Stack Overflow article](https://stackoverflow.com/questions/13061979/shared-ptr-to-an-array-should-it-be-used) about that. Looking at the code I think a refactor to `std::unique_ptr<float []>` would be pretty trivial, or `std::unique_ptr<std::vector<float>>` could also be a way to go. And no, setting the C++ standard to 17 did not fix the error. 

Would you like me to refactor FFT to one of those options?