### PR TITLE
fix portaudio on macOS Big Sur

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,7 +121,7 @@ int main(int argc, char** argv)
         glClear(GL_COLOR_BUFFER_BIT);
 
         callback.bufferSamples();
-/*
+
         fftLeft.process(callback);
         fftRight.process(callback);
         spectralMaximum.set(fftLeft.getMagnitudeSpectrum());
@@ -139,7 +139,7 @@ int main(int argc, char** argv)
         spectrumRight.update(fftRight.getMagnitudeSpectrum());
         scopeRight.plot(rangeComputer, spectrumRight.getPlotX(), spectrumRight.getPlotY(), spectrumRight.getPlotNormal());
         scopeRight.render();
-*/
+
         glfwSwapBuffers(window);
         glfwPollEvents();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@ GLFWwindow* setUpWindowAndOpenGL(const char* windowTitle)
     glewInit();
 
     if (!glCreateShader) {
-        throw std::runtime_error("Unsuccessful GL initialization.");
+        throw std::runtime_error("Unsuccessful GLEW initialization.");
     }
 
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -114,7 +114,6 @@ int main(int argc, char** argv)
 
     std::array<float, 4> color = colorFromHex(0x1d1f21);
 
-    glfwSwapInterval(1);
     glClearColor(color[0], color[1], color[2], color[3]);
 
     while (!glfwWindowShouldClose(window)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,13 @@ GLFWwindow* setUpWindowAndOpenGL(const char* windowTitle)
     glfwWindowHint(GLFW_SAMPLES, 4);
     glEnable(GL_MULTISAMPLE);
 
+#if (__APPLE__)
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+#endif
+
     GLFWwindow* window = glfwCreateWindow(g_windowWidth, g_windowHeight, windowTitle, NULL, NULL);
     if (!window) {
         glfwTerminate();
@@ -41,8 +48,9 @@ GLFWwindow* setUpWindowAndOpenGL(const char* windowTitle)
 
     glewExperimental = GL_TRUE;
     glewInit();
+
     if (!glCreateShader) {
-        throw std::runtime_error("Unsuccessful GLEW initialization.");
+        throw std::runtime_error("Unsuccessful GL initialization.");
     }
 
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -106,12 +114,14 @@ int main(int argc, char** argv)
 
     std::array<float, 4> color = colorFromHex(0x1d1f21);
 
+    glfwSwapInterval(1);
+    glClearColor(color[0], color[1], color[2], color[3]);
+
     while (!glfwWindowShouldClose(window)) {
-        glClearColor(color[0], color[1], color[2], color[3]);
         glClear(GL_COLOR_BUFFER_BIT);
 
         callback.bufferSamples();
-
+/*
         fftLeft.process(callback);
         fftRight.process(callback);
         spectralMaximum.set(fftLeft.getMagnitudeSpectrum());
@@ -129,7 +139,7 @@ int main(int argc, char** argv)
         spectrumRight.update(fftRight.getMagnitudeSpectrum());
         scopeRight.plot(rangeComputer, spectrumRight.getPlotX(), spectrumRight.getPlotY(), spectrumRight.getPlotNormal());
         scopeRight.render();
-
+*/
         glfwSwapBuffers(window);
         glfwPollEvents();
 


### PR DESCRIPTION
I updated portaudio to the latest and it seems to have fixed the portaudio issue with CoreAudio on Big Sur. Unfortunately that means I'm back to the flashing red/black screen, even with all of the rendering code commented out outside of glClear().

I found [this](https://www.glfw.org/faq.html#41---how-do-i-create-an-opengl-30-context) on the GLFW website but when I set a OpenGL 3.2 profile the GLSL v 1.2 shaders fail to compile. It seems OpenGL 3.2 wants v 1.5 GLSL. Didn't you have newer shaders at some point?
